### PR TITLE
[3] - Como usuario quiero poder recibir un histórico de cargas

### DIFF
--- a/db/migrations/20240424094214_history_charger_table.ts
+++ b/db/migrations/20240424094214_history_charger_table.ts
@@ -1,0 +1,20 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    return knex.schema.createTable('history_charger', function (table) {
+        table.increments('user_id').primary();
+        table.string('user_name').notNullable();
+        table.string('charger').notNullable();
+        table.date('start_date').notNullable();
+        table.date('end_date').notNullable();
+        table.string('status').notNullable();
+        table.string('Consumption').notNullable();
+        table.string('Cost').notNullable();
+        table.integer('duration').notNullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    return knex.schema.dropTable('history_charger');
+}
+

--- a/db/seeds/history_charger.ts
+++ b/db/seeds/history_charger.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex';
+
+export async function seed(knex: Knex){
+    await knex('history_charger').del();
+    await knex('history_charger').insert([
+        {user_id: 1, user_name: 'John Doe', charger: 'Type A', start_date: '2024-04-01', end_date: '2024-04-30', status: 'Active',
+            Consumption: 'Consumption', Cost: 'Cost', duration: 43200},
+        {user_id: 2, user_name: 'Jane Smith', charger: 'Type B', start_date: '2024-03-15', end_date: '2024-04-30', status: 'Inactive',
+            Consumption: 'Consumption', Cost: 'Cost', duration: 37800},
+        {user_id: 3, user_name: 'Alice Johnson', charger: 'Type C', start_date: '2024-04-10', end_date: '2024-04-25', status: 'Active',
+            Consumption: 'Consumption', Cost: 'Cost', duration: 21600},
+    ]);
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,11 +2,13 @@ import { FastifyInstance } from 'fastify';
 import getMessage from "./getMessage";
 import getCharger from './getCharger';
 import getAllCharger from './getAllCharger';
+import getHistoryCharger from './getHistoryCharger';
 
 async function app(fastify: FastifyInstance, opts: any){
   fastify.get('/', getMessage);
   fastify.get('/charger', getAllCharger);
   fastify.get('/charger/:id', getCharger);
+  fastify.get('/history_charger', getHistoryCharger);
 }
 
 export default app;

--- a/src/getHistoryCharger.ts
+++ b/src/getHistoryCharger.ts
@@ -1,0 +1,30 @@
+import { FastifyRequest as Request, FastifyReply as Reply } from 'fastify';
+import knexConfig from '../knexfile';
+import knex from 'knex';
+
+const knexInstance = knex(knexConfig.development);
+
+async function getHistoryCharger(request: Request, reply: Reply): Promise<void> {
+    try {
+        const chargers = await knexInstance('history_charger');
+
+        if (chargers.length > 0) {
+            reply.send({
+                data: chargers,
+            });
+        } else {
+            reply.code(404).send({
+                message: 'No chargers found',
+                success: false,
+            });
+        }
+    } catch (error) {
+        console.error('Error fetching chargers:', error);
+        reply.code(500).send({
+            message: 'Internal server error',
+            success: false,
+        });
+    }
+}
+
+export default getHistoryCharger;


### PR DESCRIPTION
**Descripción**

Resolves #3 parcialmente

Se generan nuevos archivos en migrations y seed, con los siguientes comandos:

yarn migrate:make history_charger_table
yarn seed:make history_charger

Se añade función getHistoryCharger para obtener el histórico de cargas.

