### PR TITLE
[5] - Devolver la duración de cargas en base a fecha de inicio y fecha de fin

### DIFF
--- a/db/migrations/20240424152127_charges_history_table.ts
+++ b/db/migrations/20240424152127_charges_history_table.ts
@@ -1,7 +1,7 @@
 import { Knex } from 'knex';
 
 export async function up(knex: Knex): Promise<void> {
-    return knex.schema.createTable('history_charger', function (table) {
+    return knex.schema.createTable('charges_history', function (table) {
         table.increments('user_id').primary();
         table.string('user_name').notNullable();
         table.string('charger').notNullable();
@@ -15,6 +15,6 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
-    return knex.schema.dropTable('history_charger');
+    return knex.schema.dropTable('charges_history');
 }
 

--- a/db/seeds/charges_history.ts
+++ b/db/seeds/charges_history.ts
@@ -1,8 +1,8 @@
 import { Knex } from 'knex';
 
 export async function seed(knex: Knex){
-    await knex('history_charger').del();
-    await knex('history_charger').insert([
+    await knex('charges_history').del();
+    await knex('charges_history').insert([
         {user_id: 1, user_name: 'John Doe', charger: 'Type A', start_date: '2024-04-01', end_date: '2024-04-30', status: 'Active',
             Consumption: 'Consumption', Cost: 'Cost', duration: 43200},
         {user_id: 2, user_name: 'Jane Smith', charger: 'Type B', start_date: '2024-03-15', end_date: '2024-04-30', status: 'Inactive',

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,7 +8,7 @@ async function app(fastify: FastifyInstance, opts: any){
   fastify.get('/', getMessage);
   fastify.get('/charger', getAllCharger);
   fastify.get('/charger/:id', getCharger);
-  fastify.get('/history_charger', getHistoryCharger);
+  fastify.get('/charges/:id', getHistoryCharger);
 }
 
 export default app;

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,13 +2,13 @@ import { FastifyInstance } from 'fastify';
 import getMessage from "./getMessage";
 import getCharger from './getCharger';
 import getAllCharger from './getAllCharger';
-import getHistoryCharger from './getHistoryCharger';
+import getChargesHistory from './getChargesHistory';
 
 async function app(fastify: FastifyInstance, opts: any){
   fastify.get('/', getMessage);
   fastify.get('/charger', getAllCharger);
   fastify.get('/charger/:id', getCharger);
-  fastify.get('/charges/:id', getHistoryCharger);
+  fastify.get('/charges/:id', getChargesHistory);
 }
 
 export default app;

--- a/src/getChargesHistory.ts
+++ b/src/getChargesHistory.ts
@@ -4,25 +4,25 @@ import knex from 'knex';
 
 const knexInstance = knex(knexConfig.development);
 
-async function getHistoryCharger(request: Request, reply: Reply): Promise<void> {
+async function getChargesHistory(request: Request, reply: Reply): Promise<void> {
     try {
-        const chargers = await knexInstance('charges_history');
+        const charges = await knexInstance('charges_history');
 
-        if (chargers.length > 0) {
-            chargers.forEach(charger => {
-                const startDate = new Date(charger.start_date);
-                const endDate = new Date(charger.end_date);
+        if (charges.length > 0) {
+            charges.forEach(charges => {
+                const startDate = new Date(charges.start_date);
+                const endDate = new Date(charges.end_date);
                 const durationInMilliseconds = endDate.getTime() - startDate.getTime();
                 const durationInMinutes = durationInMilliseconds / (1000 * 60);
-                charger.duration = durationInMinutes;
+                charges.duration = durationInMinutes;
             });
 
             reply.send({
-                data: chargers,
+                data: charges,
             });
         } else {
             reply.code(404).send({
-                message: 'No chargers found',
+                message: 'No charges found',
                 success: false,
             });
         }
@@ -35,4 +35,4 @@ async function getHistoryCharger(request: Request, reply: Reply): Promise<void> 
     }
 }
 
-export default getHistoryCharger;
+export default getChargesHistory;

--- a/src/getHistoryCharger.ts
+++ b/src/getHistoryCharger.ts
@@ -9,6 +9,14 @@ async function getHistoryCharger(request: Request, reply: Reply): Promise<void> 
         const chargers = await knexInstance('charges_history');
 
         if (chargers.length > 0) {
+            chargers.forEach(charger => {
+                const startDate = new Date(charger.start_date);
+                const endDate = new Date(charger.end_date);
+                const durationInMilliseconds = endDate.getTime() - startDate.getTime();
+                const durationInMinutes = durationInMilliseconds / (1000 * 60);
+                charger.duration = durationInMinutes;
+            });
+
             reply.send({
                 data: chargers,
             });

--- a/src/getHistoryCharger.ts
+++ b/src/getHistoryCharger.ts
@@ -6,7 +6,7 @@ const knexInstance = knex(knexConfig.development);
 
 async function getHistoryCharger(request: Request, reply: Reply): Promise<void> {
     try {
-        const chargers = await knexInstance('history_charger');
+        const chargers = await knexInstance('charges_history');
 
         if (chargers.length > 0) {
             reply.send({


### PR DESCRIPTION
**Descripción**

Se modifica función getHistoryCharger, con esta modificación la propiedad 'duration' de cada objeto de cargador se calculará dinámicamente en base a la diferencia entre 'start_date' y 'end_date'. Esto garantiza que obtengas la duración precisa en minutos.

Resolve #5 

**Verificación**

Entre 'start_date': '2024-03-31T22:00:00.000Z' y 'end_date': '2024-04-29T22:00:00.000Z' hay 41760 minutos de diferencia.
Entre 'start_date': '2024-03-14T23:00:00.000Z' y 'end_date': '2024-04-29T22:00:00.000Z' hay 66180 minutos de diferencia.
Entre 'start_date': '2024-04-09T22:00:00.000Z' y 'end_date': '2024-04-24T22:00:00.000Z' hay 1440 minutos de diferencia.