### PR TITLE
[8] - Devolver el coste total en base a el consumo y el precio por kWh

### DIFF
--- a/db/migrations/20240424152127_charges_history_table.ts
+++ b/db/migrations/20240424152127_charges_history_table.ts
@@ -1,7 +1,7 @@
 import { Knex } from 'knex';
 
 export async function up(knex: Knex): Promise<void> {
-    return knex.schema.createTable('history_charger', function (table) {
+    return knex.schema.createTable('charges_history', function (table) {
         table.increments('user_id').primary();
         table.string('user_name').notNullable();
         table.string('charger').notNullable();
@@ -15,6 +15,6 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
-    return knex.schema.dropTable('history_charger');
+    return knex.schema.dropTable('charges_history');
 }
 

--- a/db/seeds/charges_history.ts
+++ b/db/seeds/charges_history.ts
@@ -1,8 +1,8 @@
 import { Knex } from 'knex';
 
 export async function seed(knex: Knex){
-    await knex('history_charger').del();
-    await knex('history_charger').insert([
+    await knex('charges_history').del();
+    await knex('charges_history').insert([
         {user_id: 1, user_name: 'John Doe', charger: 'Type A', start_date: '2024-04-01', end_date: '2024-04-30', status: 'Active',
             Consumption: 'Consumption', Cost: 'Cost', duration: 43200},
         {user_id: 2, user_name: 'Jane Smith', charger: 'Type B', start_date: '2024-03-15', end_date: '2024-04-30', status: 'Inactive',

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,7 +8,7 @@ async function app(fastify: FastifyInstance, opts: any){
   fastify.get('/', getMessage);
   fastify.get('/charger', getAllCharger);
   fastify.get('/charger/:id', getCharger);
-  fastify.get('/history_charger', getHistoryCharger);
+  fastify.get('/charges/:id', getHistoryCharger);
 }
 
 export default app;

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,13 +2,13 @@ import { FastifyInstance } from 'fastify';
 import getMessage from "./getMessage";
 import getCharger from './getCharger';
 import getAllCharger from './getAllCharger';
-import getHistoryCharger from './getHistoryCharger';
+import getChargesHistory from './getChargesHistory';
 
 async function app(fastify: FastifyInstance, opts: any){
   fastify.get('/', getMessage);
   fastify.get('/charger', getAllCharger);
   fastify.get('/charger/:id', getCharger);
-  fastify.get('/charges/:id', getHistoryCharger);
+  fastify.get('/charges/:id', getChargesHistory);
 }
 
 export default app;

--- a/src/getChargesHistory.ts
+++ b/src/getChargesHistory.ts
@@ -4,25 +4,25 @@ import knex from 'knex';
 
 const knexInstance = knex(knexConfig.development);
 
-async function getHistoryCharger(request: Request, reply: Reply): Promise<void> {
+async function getChargesHistory(request: Request, reply: Reply): Promise<void> {
     try {
-        const chargers = await knexInstance('charges_history');
+        const charges = await knexInstance('charges_history');
 
-        if (chargers.length > 0) {
-            chargers.forEach(charger => {
-                const startDate = new Date(charger.start_date);
-                const endDate = new Date(charger.end_date);
+        if (charges.length > 0) {
+            charges.forEach(charges => {
+                const startDate = new Date(charges.start_date);
+                const endDate = new Date(charges.end_date);
                 const durationInMilliseconds = endDate.getTime() - startDate.getTime();
                 const durationInMinutes = durationInMilliseconds / (1000 * 60);
-                charger.duration = durationInMinutes;
+                charges.duration = durationInMinutes;
             });
 
             reply.send({
-                data: chargers,
+                data: charges,
             });
         } else {
             reply.code(404).send({
-                message: 'No chargers found',
+                message: 'No charges found',
                 success: false,
             });
         }
@@ -35,4 +35,4 @@ async function getHistoryCharger(request: Request, reply: Reply): Promise<void> 
     }
 }
 
-export default getHistoryCharger;
+export default getChargesHistory;

--- a/src/getChargesHistory.ts
+++ b/src/getChargesHistory.ts
@@ -15,6 +15,25 @@ async function getChargesHistory(request: Request, reply: Reply): Promise<void> 
                 const durationInMilliseconds = endDate.getTime() - startDate.getTime();
                 const durationInMinutes = durationInMilliseconds / (1000 * 60);
                 charges.duration = durationInMinutes;
+
+                let pricePerKWh = 0;
+                switch (charges.charger) {
+                    case 'Type A':
+                        pricePerKWh = 0.15;
+                        break;
+                    case 'Type B':
+                        pricePerKWh = 0.20;
+                        break;
+                    case 'Type C':
+                        pricePerKWh = 0.25;
+                        break;
+                    default:
+                        pricePerKWh = 0;
+                }
+
+                const totalCost = (charges.Consumption || 0) * pricePerKWh;
+                charges.Cost = totalCost;
+
             });
 
             reply.send({

--- a/src/getHistoryCharger.ts
+++ b/src/getHistoryCharger.ts
@@ -9,6 +9,14 @@ async function getHistoryCharger(request: Request, reply: Reply): Promise<void> 
         const chargers = await knexInstance('charges_history');
 
         if (chargers.length > 0) {
+            chargers.forEach(charger => {
+                const startDate = new Date(charger.start_date);
+                const endDate = new Date(charger.end_date);
+                const durationInMilliseconds = endDate.getTime() - startDate.getTime();
+                const durationInMinutes = durationInMilliseconds / (1000 * 60);
+                charger.duration = durationInMinutes;
+            });
+
             reply.send({
                 data: chargers,
             });

--- a/src/getHistoryCharger.ts
+++ b/src/getHistoryCharger.ts
@@ -6,7 +6,7 @@ const knexInstance = knex(knexConfig.development);
 
 async function getHistoryCharger(request: Request, reply: Reply): Promise<void> {
     try {
-        const chargers = await knexInstance('history_charger');
+        const chargers = await knexInstance('charges_history');
 
         if (chargers.length > 0) {
             reply.send({


### PR DESCRIPTION
**Descripción**

Añadir switch para devolver el coste total en base a el consumo y el precio por kWh, el precio de kWh depende del tipo de cargador que sea, en el caso del cargador de tipo A el precio es de 0.15, en el caso de tipo B el precio es de 0.20 y por último en el caso de tipo C el precio es de 0.25.

Resolve #8 

**Verificación**

Se modifica campo de 'Consumption' en db para observar que obtenemos en el campo de 'Cost' el coste que corresponde.
En el caso del cargador de tipo A hemos supuesto que el campo 'Consumption' tenía un valor de 1000 por lo tanto en el campo de 'Cost' deberíamos de obtener 150.
En el caso del cargador de tipo B hemos supuesto que el campo 'Consumption' tenía un valor de 1500 por lo tanto en el campo de 'Cost' deberíamos de obtener 300.
En el caso del cargador de tipo C hemos supuesto que el campo 'Consumption' tenía un valor de 2000 por lo tanto en el campo de 'Cost' deberíamos de obtener 500.