### PR TITLE
[8] - Devolver el coste total en base a el consumo y el precio por kWh

### DIFF
--- a/db/migrations/20240424152127_charges_history_table.ts
+++ b/db/migrations/20240424152127_charges_history_table.ts
@@ -8,9 +8,7 @@ export async function up(knex: Knex): Promise<void> {
         table.date('start_date').notNullable();
         table.date('end_date').notNullable();
         table.string('status').notNullable();
-        table.string('Consumption').notNullable();
-        table.string('Cost').notNullable();
-        table.integer('duration').notNullable();
+        table.integer('consumption').notNullable();
     });
 }
 

--- a/db/seeds/charges_history.ts
+++ b/db/seeds/charges_history.ts
@@ -4,10 +4,10 @@ export async function seed(knex: Knex){
     await knex('charges_history').del();
     await knex('charges_history').insert([
         {user_id: 1, user_name: 'John Doe', charger: 'Type A', start_date: '2024-04-01', end_date: '2024-04-30', status: 'Active',
-            Consumption: 'Consumption', Cost: 'Cost', duration: 43200},
+            consumption: 1000},
         {user_id: 2, user_name: 'Jane Smith', charger: 'Type B', start_date: '2024-03-15', end_date: '2024-04-30', status: 'Inactive',
-            Consumption: 'Consumption', Cost: 'Cost', duration: 37800},
+            consumption: 1500},
         {user_id: 3, user_name: 'Alice Johnson', charger: 'Type C', start_date: '2024-04-10', end_date: '2024-04-25', status: 'Active',
-            Consumption: 'Consumption', Cost: 'Cost', duration: 21600},
+            consumption: 2000},
     ]);
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,14 +1,14 @@
 import { FastifyInstance } from 'fastify';
 import getMessage from "./getMessage";
-import getCharger from './getCharger';
 import getAllCharger from './getAllCharger';
+import getCharger from './getCharger';
 import getChargesHistory from './getChargesHistory';
 
 async function app(fastify: FastifyInstance, opts: any){
   fastify.get('/', getMessage);
   fastify.get('/charger', getAllCharger);
   fastify.get('/charger/:id', getCharger);
-  fastify.get('/charges/:id', getChargesHistory);
+  fastify.get('/charges', getChargesHistory);
 }
 
 export default app;

--- a/src/getChargesHistory.ts
+++ b/src/getChargesHistory.ts
@@ -15,6 +15,25 @@ async function getChargesHistory(request: Request, reply: Reply): Promise<void> 
                 const durationInMilliseconds = endDate.getTime() - startDate.getTime();
                 const durationInMinutes = durationInMilliseconds / (1000 * 60);
                 charges.duration = durationInMinutes;
+
+                let pricePerKWh = 0;
+                switch (charges.charger) {
+                    case 'Type A':
+                        pricePerKWh = 0.15;
+                        break;
+                    case 'Type B':
+                        pricePerKWh = 0.20;
+                        break;
+                    case 'Type C':
+                        pricePerKWh = 0.25;
+                        break;
+                    default:
+                        pricePerKWh = 0;
+                }
+
+                const totalCost = (charges.Consumption || 0) * pricePerKWh;
+                charges.Cost = totalCost;
+
             });
 
             reply.send({


### PR DESCRIPTION
**Descripción**

Añadir switch para devolver el coste total en base a el consumo y el precio por kWh, el precio de kWh depende del tipo de cargador que sea, en el caso del cargador de tipo A el precio es de 0.15, en el caso de tipo B el precio es de 0.20 y por último en el caso de tipo C el precio es de 0.25.

Resolve #8 

**Verificación**

Configurar la solicitud: http://127.0.0.1:3000/charges

Enviar y revisar respuesta:

{
    "data": [
        {
            "user_id": 1,
            "user_name": "John Doe",
            "charger": "Type A",
            "start_date": "2024-03-31T22:00:00.000Z",
            "end_date": "2024-04-29T22:00:00.000Z",
            "status": "Active",
            "consumption": "1000",
            "duration": 41760,
            "cost": 150
        },
        {
            "user_id": 2,
            "user_name": "Jane Smith",
            "charger": "Type B",
            "start_date": "2024-03-14T23:00:00.000Z",
            "end_date": "2024-04-29T22:00:00.000Z",
            "status": "Inactive",
            "consumption": "1500",
            "duration": 66180,
            "cost": 300
        },
        {
            "user_id": 3,
            "user_name": "Alice Johnson",
            "charger": "Type C",
            "start_date": "2024-04-09T22:00:00.000Z",
            "end_date": "2024-04-24T22:00:00.000Z",
            "status": "Active",
            "consumption": "2000",
            "duration": 21600,
            "cost": 500
        }
    ]
}

