### PR TITLE
[15] - Endpoint que devuelva un listado de empresas en base al parámetro que nos pasen

### DIFF
--- a/src/companyModel.ts
+++ b/src/companyModel.ts
@@ -1,0 +1,7 @@
+export interface Company {
+    id: number;
+    name: string;
+    founded_year: number;
+    revenue: number;
+    employees_count: number;
+}

--- a/src/companyRepository.ts
+++ b/src/companyRepository.ts
@@ -9,21 +9,17 @@ export interface CompanyRepository {
 }
 
 export class KnexCompanyRepository implements CompanyRepository {
-    async getCompaniesSortedBy(sortBy?: string): Promise<Company[]> {
-        if (sortBy === undefined) {
-            const companies = await knexInstance('company');
-            if (companies.length === 0) {
-                throw new Error('No hay compañías');
-            }
-            return companies;
-        }
-
+    async getCompaniesSortedBy(sortBy?: string, sortDirection?: string): Promise<Company[]> {
         if (sortBy === 'employees') {
-            return knexInstance('company').select('*').orderBy('employees_count', 'desc');
+            return knexInstance('company').select('*').orderBy('employees_count', sortDirection);
         }
 
         if (sortBy === 'year') {
-            return knexInstance('company').select('*').orderBy('founded_year', 'asc');
+            return knexInstance('company').select('*').orderBy('founded_year', sortDirection);
+        }
+
+        if (sortBy === undefined) {
+            return knexInstance('company');
         }
 
         throw new Error('sortBy no válido');

--- a/src/companyRepository.ts
+++ b/src/companyRepository.ts
@@ -1,0 +1,31 @@
+import knexConfig from '../knexfile';
+import knex from 'knex';
+import { Company } from './companyModel';
+
+const knexInstance = knex(knexConfig.development);
+
+export interface CompanyRepository {
+    getCompaniesSortedBy(sortBy: string): Promise<Company[]>;
+}
+
+export class KnexCompanyRepository implements CompanyRepository {
+    async getCompaniesSortedBy(sortBy?: string): Promise<Company[]> {
+        if (sortBy === undefined) {
+            const companies = await knexInstance('company');
+            if (companies.length === 0) {
+                throw new Error('No hay compañías');
+            }
+            return companies;
+        }
+
+        if (sortBy === 'employees') {
+            return knexInstance('company').select('*').orderBy('employees_count', 'desc');
+        }
+
+        if (sortBy === 'year') {
+            return knexInstance('company').select('*').orderBy('founded_year', 'asc');
+        }
+
+        throw new Error('sortBy no válido');
+    }
+}

--- a/src/getCompanies.ts
+++ b/src/getCompanies.ts
@@ -3,30 +3,29 @@ import { KnexCompanyRepository } from './companyRepository';
 
 export const getCompanies = async function getCompanies(request: Request, reply: Reply): Promise<void> {
     try {
-        const { order_by} = request.query as { order_by: string };
+        const { orderBy} = request.query as { orderBy: string };
 
-        if (order_by === '') {
-            reply.code(400).send({ error: 'order_by no puede ser vacío' });
+        if (orderBy === '') {
+            reply.code(400).send({ error: 'orderBy no puede ser vacío' });
         }
 
-        if (order_by !== undefined && order_by !== 'employees' && order_by !== 'year') {
-            reply.code(400).send({ error: 'order_by no válido' });
+        if (orderBy !== undefined && orderBy !== 'employees' && orderBy !== 'year') {
+            reply.code(400).send({ error: 'orderBy no válido' });
         }
 
         const companyRepository = new KnexCompanyRepository();
 
         let sortDirection = 'desc';
-        if (order_by === 'year') {
+        if (orderBy === 'year') {
             sortDirection = 'asc';
         }
 
-        const companies = await companyRepository.getCompaniesSortedBy(order_by, sortDirection);
-        reply.send({ data: companies });
-
+        const companies = await companyRepository.getCompaniesSortedBy(orderBy, sortDirection);
         if (companies.length === 0) {
             reply.code(400).send({ error: 'No hay compañías' });
+        } else {
+            reply.send({ data: companies });
         }
-
     } catch (error) {
         console.error('Error fetching companies:', error);
         reply.code(500).send({ message: 'Internal server error' });

--- a/src/getCompanies.ts
+++ b/src/getCompanies.ts
@@ -1,9 +1,9 @@
 import { FastifyRequest as Request, FastifyReply as Reply } from 'fastify';
-import { CompanyRepository, KnexCompanyRepository } from './companyRepository';
+import { KnexCompanyRepository } from './companyRepository';
 
 export const getCompanies = async function getCompanies(request: Request, reply: Reply): Promise<void> {
     try {
-        const { order_by } = request.query as { order_by: string };
+        const { order_by} = request.query as { order_by: string };
 
         if (order_by === '') {
             reply.code(400).send({ error: 'order_by no puede ser vacío' });
@@ -13,10 +13,19 @@ export const getCompanies = async function getCompanies(request: Request, reply:
             reply.code(400).send({ error: 'order_by no válido' });
         }
 
-        const companyRepository: CompanyRepository = new KnexCompanyRepository();
+        const companyRepository = new KnexCompanyRepository();
 
-        const companies = await companyRepository.getCompaniesSortedBy(order_by);
+        let sortDirection = 'desc';
+        if (order_by === 'year') {
+            sortDirection = 'asc';
+        }
+
+        const companies = await companyRepository.getCompaniesSortedBy(order_by, sortDirection);
         reply.send({ data: companies });
+
+        if (companies.length === 0) {
+            reply.code(400).send({ error: 'No hay compañías' });
+        }
 
     } catch (error) {
         console.error('Error fetching companies:', error);

--- a/src/getCompanies.ts
+++ b/src/getCompanies.ts
@@ -1,8 +1,5 @@
 import { FastifyRequest as Request, FastifyReply as Reply } from 'fastify';
-import knexConfig from '../knexfile';
-import knex from 'knex';
-
-const knexInstance = knex(knexConfig.development);
+import { CompanyRepository, KnexCompanyRepository } from './companyRepository';
 
 export const getCompanies = async function getCompanies(request: Request, reply: Reply): Promise<void> {
     try {
@@ -16,28 +13,13 @@ export const getCompanies = async function getCompanies(request: Request, reply:
             reply.code(400).send({ error: 'order_by no válido' });
         }
 
-        let companies;
+        const companyRepository: CompanyRepository = new KnexCompanyRepository();
 
-        if (order_by === undefined) {
-            companies = await knexInstance('company');
-            if (companies.length === 0) {
-                reply.code(200).send({ estado: 'No hay compañías' });
-            }
-            reply.send({ data: companies });
-        }
-
-        if (order_by === 'employees') {
-            companies = await knexInstance('company').select('*').orderBy('employees_count', 'desc');
-            reply.send({ data: companies });
-        }
-
-        if (order_by === 'year') {
-            companies = await knexInstance('company').select('*').orderBy('founded_year', 'asc');
-            reply.send({ data: companies });
-        }
+        const companies = await companyRepository.getCompaniesSortedBy(order_by);
+        reply.send({ data: companies });
 
     } catch (error) {
         console.error('Error fetching companies:', error);
         reply.code(500).send({ message: 'Internal server error' });
     }
-}
+};

--- a/src/getCompanies.ts
+++ b/src/getCompanies.ts
@@ -10,12 +10,10 @@ export const getCompanies = async function getCompanies(request: Request, reply:
 
         if (order_by === '') {
             reply.code(400).send({ error: 'order_by no puede ser vacío' });
-            return;
         }
 
         if (order_by !== undefined && order_by !== 'employees' && order_by !== 'year') {
             reply.code(400).send({ error: 'order_by no válido' });
-            return;
         }
 
         let companies;
@@ -24,17 +22,20 @@ export const getCompanies = async function getCompanies(request: Request, reply:
             companies = await knexInstance('company');
             if (companies.length === 0) {
                 reply.code(200).send({ estado: 'No hay compañías' });
-                return;
             }
-        } else {
-            if (order_by === 'employees') {
-                companies = await knexInstance('company').select('*').orderBy('employees_count', 'desc');
-            } else if (order_by === 'year') {
-                companies = await knexInstance('company').select('*').orderBy('founded_year', 'asc');
-            }
+            reply.send({ data: companies });
         }
 
-        reply.send({ data: companies });
+        if (order_by === 'employees') {
+            companies = await knexInstance('company').select('*').orderBy('employees_count', 'desc');
+            reply.send({ data: companies });
+        }
+
+        if (order_by === 'year') {
+            companies = await knexInstance('company').select('*').orderBy('founded_year', 'asc');
+            reply.send({ data: companies });
+        }
+
     } catch (error) {
         console.error('Error fetching companies:', error);
         reply.code(500).send({ message: 'Internal server error' });


### PR DESCRIPTION
**Descripción**

Modificar función getCompanies teniendo en cuenta las siguientes reglas:

* Si no hay ninguna compañía en vez de devolver el listado de usuarios, devolveremos un mensaje 200 {"estado" : "No hay compañías" }
* Si no se pasa ningún parámetro a la petición, devolveremos el listado sin ningún tipo de orden
* Si por parámetro nos pasan el campo orderBy filtraremos la respuesta en base al parámetro que nos pasen:
    * /companies?orderBy=employees -> devolveremos el listado ordenador de mayor a menor por número de empleados
    * /companies?orderBy=year -> devolveremos el listado ordenador de más antigua a nueva en base a año de creación de empresa
* Si nos pasan el parámetro orderBy vacío, devolveremos un error 400 -> { "error": "orderBy no puede ser vacío"}
* Si nos pasan el parámetro orderBy con otro valor que no sea employees o year, devolveremos un error 400 -> { "error": "orderBy no válido"}

Resolve #15

**Verificación**

http://127.0.0.1:3000/companies
```
{
    "data": [
        {
            "company_id": 1,
            "name": "Tesla Inc.",
            "founded_year": 2003,
            "revenue": "4680.00",
            "employees_count": 70000
        },
        {
            "company_id": 2,
            "name": "Apple Inc.",
            "founded_year": 1976,
            "revenue": "365.00",
            "employees_count": 154000
        },
        {
            "company_id": 3,
            "name": "Google LLC",
            "founded_year": 1998,
            "revenue": "2000.00",
            "employees_count": 150000
        }
    ]
}
```
http://127.0.0.1:3000/companies?orderBy=employees

http://127.0.0.1:3000/companies?orderBy=year
```
{
    "data": [
        {
            "company_id": 2,
            "name": "Apple Inc.",
            "founded_year": 1976,
            "revenue": "365.00",
            "employees_count": 154000
        },
        {
            "company_id": 3,
            "name": "Google LLC",
            "founded_year": 1998,
            "revenue": "2000.00",
            "employees_count": 150000
        },
        {
            "company_id": 1,
            "name": "Tesla Inc.",
            "founded_year": 2003,
            "revenue": "4680.00",
            "employees_count": 70000
        }
    ]
}
```
http://127.0.0.1:3000/companies?orderBy=
```
{
    "error": "orderBy no puede ser vacío"
}
```
http://127.0.0.1:3000/companies?orderBy=540
```
{
    "error": "orderBy no válido"
}
```