### PR TITLE
[18] - Generar token de autenticación con respuesta de error

### DIFF
--- a/db/migrations/20240507105250_update_company_table.ts
+++ b/db/migrations/20240507105250_update_company_table.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    return knex.schema.table('company', function (table) {
+        table.string('secret').notNullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    return knex.schema.table('company', function (table) {
+        table.dropColumn('secret');
+    });
+}

--- a/db/seeds/company.ts
+++ b/db/seeds/company.ts
@@ -2,8 +2,8 @@ import { Knex } from 'knex';
 export async function seed(knex: Knex){
     await knex('company').del();
     await knex('company').insert([
-        {id: 1, name: 'Tesla Inc.', founded_year: 2003, revenue: 4680.00, employees_count: 70000},
-        {id: 2, name: 'Apple Inc.', founded_year: 1976, revenue: 365.00, employees_count: 154000},
-        {id: 3, name: 'Google LLC', founded_year: 1998, revenue: 2000.00, employees_count: 150000},
+        {id: 1, name: 'Tesla Inc.', founded_year: 2003, revenue: 4680.00, employees_count: 70000, secret: 'secret_1'},
+        {id: 2, name: 'Apple Inc.', founded_year: 1976, revenue: 365.00, employees_count: 154000, secret: 'secret_2'},
+        {id: 3, name: 'Google LLC', founded_year: 1998, revenue: 2000.00, employees_count: 150000, secret: 'secret_3'},
     ]);
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,6 +4,7 @@ import getAllCharger from './getAllCharger';
 import getCharger from './getCharger';
 import getChargesHistory from './getChargesHistory';
 import { getCompanies } from './getCompanies';
+import { generateToken } from './generateToken';
 
 async function app(fastify: FastifyInstance, opts: any){
   fastify.get('/', getMessage);
@@ -11,6 +12,7 @@ async function app(fastify: FastifyInstance, opts: any){
   fastify.get('/charger/:id', getCharger);
   fastify.get('/charges', getChargesHistory);
   fastify.get('/companies', getCompanies);
+  fastify.post('/oauth/token', generateToken);
 }
 
 export default app;

--- a/src/companyModel.ts
+++ b/src/companyModel.ts
@@ -4,4 +4,5 @@ export interface Company {
     founded_year: number;
     revenue: number;
     employees_count: number;
+    secret: string;
 }

--- a/src/companyRepository.ts
+++ b/src/companyRepository.ts
@@ -6,7 +6,7 @@ const knexInstance = knex(knexConfig.development);
 
 export interface CompanyRepository {
     getCompaniesSortedBy(sortBy: string): Promise<Company[]>;
-    findByCredentials(id: number, secret: string): Promise<Company | null>;
+    findByToken(id: number, secret: string): Promise<Company | null>;
 }
 
 export class KnexCompanyRepository implements CompanyRepository {
@@ -26,7 +26,7 @@ export class KnexCompanyRepository implements CompanyRepository {
         throw new Error('sortBy no válido');
     }
 
-    async findByCredentials(id: number, secret: string) {
+    async findByToken(id: number, secret: string) {
         return knexInstance('company').where({ id, secret }).first();
     }
 }

--- a/src/companyRepository.ts
+++ b/src/companyRepository.ts
@@ -24,4 +24,8 @@ export class KnexCompanyRepository implements CompanyRepository {
 
         throw new Error('sortBy no válido');
     }
+
+    async findByCredentials(id: number, secret: string) {
+        return knexInstance('company').where({ id, secret }).first();
+    }
 }

--- a/src/companyRepository.ts
+++ b/src/companyRepository.ts
@@ -26,7 +26,7 @@ export class KnexCompanyRepository implements CompanyRepository {
         throw new Error('sortBy no válido');
     }
 
-    async findByToken(id: number, secret: string) {
+    async findByToken(id: number, secret: string): Promise<Company | null> {
         return knexInstance('company').where({ id, secret }).first();
     }
 }

--- a/src/companyRepository.ts
+++ b/src/companyRepository.ts
@@ -6,6 +6,7 @@ const knexInstance = knex(knexConfig.development);
 
 export interface CompanyRepository {
     getCompaniesSortedBy(sortBy: string): Promise<Company[]>;
+    findByCredentials(id: number, secret: string): Promise<Company | null>;
 }
 
 export class KnexCompanyRepository implements CompanyRepository {

--- a/src/generateToken.ts
+++ b/src/generateToken.ts
@@ -11,7 +11,7 @@ export const generateToken = async (request: Request, reply: Reply): Promise<voi
             reply.code(400).send({ error: 'Verifica el id y el secret son obligatorios.' });
         }
 
-        const isValid = await verifyCredentials(parseInt(id), secret);
+        const isValid = await verifyToken(parseInt(id), secret);
 
         if (!isValid) {
             reply.code(400).send({ error: 'Credenciales inválidas. Verifica el id y el secret proporcionados.' });
@@ -22,8 +22,8 @@ export const generateToken = async (request: Request, reply: Reply): Promise<voi
     }
 }
 
-async function verifyCredentials(id: number, secret: string): Promise<boolean> {
-    const company = await companyRepository.findByCredentials(id, secret);
+async function verifyToken(id: number, secret: string): Promise<boolean> {
+    const company = await companyRepository.findByToken(id, secret);
     return !!company;
 }
 

--- a/src/generateToken.ts
+++ b/src/generateToken.ts
@@ -1,0 +1,31 @@
+import { FastifyRequest as Request, FastifyReply as Reply } from 'fastify';
+import knexConfig from '../knexfile';
+import knex from 'knex';
+
+const knexInstance = knex(knexConfig.development);
+
+async function verifyCredentials(id: number, secret: string): Promise<boolean> {
+    const company = await knexInstance('company').where({ id, secret }).first();
+    return !!company;
+}
+export const generateToken = async function generateToken(request: Request, reply: Reply): Promise<void> {
+    try {
+
+        const { id, secret } = request.body as { id: number; secret: string };
+
+        if (!id || !secret) {
+            reply.code(400).send({ error: 'Verifica el id y el secret son obligatorios.' });
+        }
+
+        const isValid = await verifyCredentials(id, secret);
+
+        if (!isValid) {
+            reply.code(400).send({ error: 'Credenciales inválidas. Verifica el id y el secret proporcionados.' });
+        }
+
+    } catch (error) {
+        console.error('Error', error);
+        reply.code(500).send({ message: 'Internal server error' });
+    }
+}
+

--- a/src/generateToken.ts
+++ b/src/generateToken.ts
@@ -11,9 +11,7 @@ export const generateToken = async (request: Request, reply: Reply): Promise<voi
             reply.code(400).send({ error: 'Verifica el id y el secret son obligatorios.' });
         }
 
-        const numericId: number = parseInt(id);
-
-        const isValid = await verifyCredentials(numericId, secret);
+        const isValid = await verifyCredentials(parseInt(id), secret);
 
         if (!isValid) {
             reply.code(400).send({ error: 'Credenciales inválidas. Verifica el id y el secret proporcionados.' });

--- a/src/generateToken.ts
+++ b/src/generateToken.ts
@@ -1,31 +1,31 @@
 import { FastifyRequest as Request, FastifyReply as Reply } from 'fastify';
-import knexConfig from '../knexfile';
-import knex from 'knex';
+import { KnexCompanyRepository } from './companyRepository';
 
-const knexInstance = knex(knexConfig.development);
+const companyRepository = new KnexCompanyRepository();
 
-async function verifyCredentials(id: number, secret: string): Promise<boolean> {
-    const company = await knexInstance('company').where({ id, secret }).first();
-    return !!company;
-}
-export const generateToken = async function generateToken(request: Request, reply: Reply): Promise<void> {
+export const generateToken = async (request: Request, reply: Reply): Promise<void> => {
     try {
-
-        const { id, secret } = request.body as { id: number; secret: string };
+        const { id, secret } = request.body as { id: string; secret: string };
 
         if (!id || !secret) {
             reply.code(400).send({ error: 'Verifica el id y el secret son obligatorios.' });
         }
 
-        const isValid = await verifyCredentials(id, secret);
+        const numericId: number = parseInt(id);
+
+        const isValid = await verifyCredentials(numericId, secret);
 
         if (!isValid) {
             reply.code(400).send({ error: 'Credenciales inválidas. Verifica el id y el secret proporcionados.' });
         }
 
     } catch (error) {
-        console.error('Error', error);
         reply.code(500).send({ message: 'Internal server error' });
     }
+}
+
+async function verifyCredentials(id: number, secret: string): Promise<boolean> {
+    const company = await companyRepository.findByCredentials(id, secret);
+    return !!company;
 }
 


### PR DESCRIPTION
**Descripción**
Este endpoint permite generar un token de autenticación mediante la provisión de un id y un secret. Hemos tenido solo en cuenta los mensajes de error.

Resolve #18 

**Verificación**
POST http://localhost:3000/oauth/token

En la pestaña "Body" en Postman, seleccionamos "raw" y "JSON"
```
{
   
}
```
Body:
```
{
    "error": "Verifica el id y el secret son obligatorios."
}
```

POST http://localhost:3000/oauth/token

En la pestaña "Body" en Postman, seleccionamos "raw" y "JSON"
```
{
    "id": 1,
    "secret": "secret"
}
```
Body:
```
{
    "error": "Credenciales inválidas. Verifica el id y el secret proporcionados."
}
```
