### PR TITLE
[22] - Refrescar token de autenticación con respuesta de error

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -5,6 +5,7 @@ import getCharger from './getCharger';
 import getChargesHistory from './getChargesHistory';
 import { getCompanies } from './getCompanies';
 import { insertToken } from './insertToken';
+import { refreshToken } from './refreshToken';
 
 async function app(fastify: FastifyInstance, opts: any){
   fastify.get('/', getMessage);
@@ -13,6 +14,7 @@ async function app(fastify: FastifyInstance, opts: any){
   fastify.get('/charges', getChargesHistory);
   fastify.get('/companies', getCompanies);
   fastify.post('/oauth/token', insertToken);
+  fastify.post('/oauth/refresh-token', refreshToken);
 }
 
 export default app;

--- a/src/refreshToken.ts
+++ b/src/refreshToken.ts
@@ -1,0 +1,22 @@
+import { FastifyRequest as Request, FastifyReply as Reply } from 'fastify';
+import { KnexTokenRepository } from './repositories/tokenRepository';
+
+const tokenRepository = new KnexTokenRepository();
+
+export async function refreshToken(request: Request, reply: Reply): Promise<void> {
+    const { id, secret, refresh_token } = request.body as { id: string; secret: string; refresh_token: string };
+
+    try {
+        if (!id || !secret || !refresh_token) {
+            reply.code(400).send({ error: 'Credenciales inválidas. Verifica el company_id, secret y refresh_token proporcionados.' });
+        }
+        const companyId: number = parseInt(id);
+        const isValidRefreshToken = await tokenRepository.validateRefreshToken(companyId, refresh_token);
+
+        if (!isValidRefreshToken) {
+            reply.code(401).send({ error: 'Acceso no autorizado. El refresh_token es inválido o ha expirado.' });
+        }
+    } catch (error) {
+        reply.code(500).send({ message: 'Internal server error' });
+    }
+}

--- a/src/repositories/tokenRepository.ts
+++ b/src/repositories/tokenRepository.ts
@@ -6,10 +6,20 @@ const knexInstance = knex(knexConfig.development);
 
 export interface tokenRepository {
     insertToken(token: Token): Promise<void>;
+    validateRefreshToken(companyId: number, refreshToken: string): Promise<boolean>;
 }
 
 export class KnexTokenRepository implements tokenRepository {
     async insertToken(token: Token): Promise<void> {
         await knexInstance('token').insert(token);
+    }
+    async validateRefreshToken(companyId: number, refreshToken: string): Promise<boolean> {
+        const token = await knexInstance('token')
+            .where({
+                company_id: companyId,
+                refresh_token: refreshToken
+            })
+            .first();
+        return !!token;
     }
 }


### PR DESCRIPTION
**Descripción**
Este endpoint permite refrescar un token de acceso (access_token) utilizando un refresh_token válido, junto con la autenticación del company mediante company_id y secret. Hemos tenido en cuenta las respuestas erróneas.

Resolve #22

**Verificación**
POST http://localhost:3000/oauth/refresh-token

En la pestaña "Body" en Postman, seleccionamos "raw" y "JSON"
```
{
    "id": 3,
    "secret": "secret_3"
}
```
Body:
```
{
  "error": "Credenciales inválidas. Verifica el company_id, secret y refresh_token proporcionados."
}
```
POST http://localhost:3000/oauth/refresh-token

En la pestaña "Body" en Postman, seleccionamos "raw" y "JSON"
```
{
    "id": 3,
    "secret": "secret_3”,
    "refresh_token": “3”
}
```
Body:
```
{
    "error": "Acceso no autorizado. El refresh_token es inválido o ha expirado."
}
```