### PR TITLE
[24] - Refrescar token de autenticación con respuesta de éxito

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -5,6 +5,7 @@ import getCharger from './getCharger';
 import getChargesHistory from './getChargesHistory';
 import { getCompanies } from './getCompanies';
 import { insertToken } from './insertToken';
+import { refreshToken } from './refreshToken';
 
 async function app(fastify: FastifyInstance, opts: any){
   fastify.get('/', getMessage);
@@ -13,6 +14,7 @@ async function app(fastify: FastifyInstance, opts: any){
   fastify.get('/charges', getChargesHistory);
   fastify.get('/companies', getCompanies);
   fastify.post('/oauth/token', insertToken);
+  fastify.post('/oauth/refresh-token', refreshToken);
 }
 
 export default app;

--- a/src/generateToken.ts
+++ b/src/generateToken.ts
@@ -1,0 +1,5 @@
+export function generateToken(): string {
+    const currentTime: string = new Date().getTime().toString();
+    const randomValue: string = Math.floor(Math.random() * 10000).toString();
+    return currentTime + randomValue;
+}

--- a/src/insertToken.ts
+++ b/src/insertToken.ts
@@ -2,6 +2,7 @@ import { FastifyRequest as Request, FastifyReply as Reply } from 'fastify';
 import { KnexTokenRepository } from './repositories/tokenRepository';
 import { KnexCompanyRepository } from './repositories/companyRepository';
 import { Token } from './models/tokenModel';
+import { generateToken } from './generateToken'
 
 const tokenRepository = new KnexTokenRepository();
 const companyRepository = new KnexCompanyRepository();
@@ -21,8 +22,8 @@ export async function insertToken(request: Request, reply: Reply): Promise<void>
             reply.code(400).send({ error: 'Credenciales inválidas. Verifica el id y el secret proporcionados.' });
         }
 
-        const accessToken: string = accessRefreshToken();
-        const refreshToken: string = accessRefreshToken();
+        const accessToken: string = insertTokens();
+        const refreshToken: string = insertTokens();
         const expiresIn = new Date();
         expiresIn.setDate(expiresIn.getDate() + 7);
 
@@ -45,8 +46,6 @@ export async function insertToken(request: Request, reply: Reply): Promise<void>
     }
 }
 
-function accessRefreshToken(): string {
-    const currentTime: string = new Date().getTime().toString();
-    const randomValue: string = Math.floor(Math.random() * 10000).toString();
-    return currentTime + randomValue;
+function insertTokens(): string {
+    return generateToken()
 }

--- a/src/refreshToken.ts
+++ b/src/refreshToken.ts
@@ -1,6 +1,7 @@
 import { FastifyRequest as Request, FastifyReply as Reply } from 'fastify';
 import { KnexTokenRepository } from './repositories/tokenRepository';
 import { Token } from './models/tokenModel';
+import { generateToken } from './generateToken'
 
 const tokenRepository = new KnexTokenRepository();
 
@@ -21,7 +22,7 @@ export async function refreshToken(request: Request, reply: Reply): Promise<void
         const accessToken: string = accessRefreshToken();
         const refreshToken: string = accessRefreshToken();
         const expiresIn = new Date();
-        expiresIn.setDate(expiresIn.getDate() + 7);
+        expiresIn.setDate(expiresIn.getDate() + 14);
 
         const token: Token = {
             access_token: accessToken,
@@ -42,7 +43,5 @@ export async function refreshToken(request: Request, reply: Reply): Promise<void
 }
 
 function accessRefreshToken(): string {
-    const currentTime: string = new Date().getTime().toString();
-    const randomValue: string = Math.floor(Math.random() * 10000).toString();
-    return currentTime + randomValue;
+    return generateToken();
 }

--- a/src/refreshToken.ts
+++ b/src/refreshToken.ts
@@ -1,0 +1,22 @@
+import { FastifyRequest as Request, FastifyReply as Reply } from 'fastify';
+import { KnexTokenRepository } from './repositories/tokenRepository';
+
+const tokenRepository = new KnexTokenRepository();
+
+export async function refreshToken(request: Request, reply: Reply): Promise<void> {
+    const { id, secret, refresh_token } = request.body as { id: string; secret: string; refresh_token: string };
+
+    try {
+        if (!id || !secret || !refresh_token) {
+            reply.code(400).send({ error: 'Credenciales inválidas. Verifica el company_id, secret y refresh_token proporcionados.' });
+        }
+        const companyId: number = parseInt(id);
+        const isValidRefreshToken = await tokenRepository.validateRefreshToken(companyId, refresh_token);
+
+        if (!isValidRefreshToken) {
+            reply.code(401).send({ error: 'Acceso no autorizado. El refresh_token es inválido o ha expirado.' });
+        }
+    } catch (error) {
+        reply.code(500).send({ message: 'Internal server error' });
+    }
+}

--- a/src/refreshToken.ts
+++ b/src/refreshToken.ts
@@ -1,5 +1,6 @@
 import { FastifyRequest as Request, FastifyReply as Reply } from 'fastify';
 import { KnexTokenRepository } from './repositories/tokenRepository';
+import { Token } from './models/tokenModel';
 
 const tokenRepository = new KnexTokenRepository();
 
@@ -16,7 +17,32 @@ export async function refreshToken(request: Request, reply: Reply): Promise<void
         if (!isValidRefreshToken) {
             reply.code(401).send({ error: 'Acceso no autorizado. El refresh_token es inválido o ha expirado.' });
         }
+
+        const accessToken: string = accessRefreshToken();
+        const refreshToken: string = accessRefreshToken();
+        const expiresIn = new Date();
+        expiresIn.setDate(expiresIn.getDate() + 7);
+
+        const token: Token = {
+            access_token: accessToken,
+            expires_in: expiresIn,
+            refresh_token: refreshToken,
+            company_id: companyId
+        };
+
+        await tokenRepository.insertToken(token);
+
+        reply.code(200).send({
+            access_token: accessToken,
+            expires_in: expiresIn
+        });
     } catch (error) {
         reply.code(500).send({ message: 'Internal server error' });
     }
+}
+
+function accessRefreshToken(): string {
+    const currentTime: string = new Date().getTime().toString();
+    const randomValue: string = Math.floor(Math.random() * 10000).toString();
+    return currentTime + randomValue;
 }

--- a/src/repositories/tokenRepository.ts
+++ b/src/repositories/tokenRepository.ts
@@ -6,10 +6,20 @@ const knexInstance = knex(knexConfig.development);
 
 export interface tokenRepository {
     insertToken(token: Token): Promise<void>;
+    validateRefreshToken(companyId: number, refreshToken: string): Promise<boolean>;
 }
 
 export class KnexTokenRepository implements tokenRepository {
     async insertToken(token: Token): Promise<void> {
         await knexInstance('token').insert(token);
+    }
+    async validateRefreshToken(companyId: number, refreshToken: string): Promise<boolean> {
+        const token = await knexInstance('token')
+            .where({
+                company_id: companyId,
+                refresh_token: refreshToken
+            })
+            .first();
+        return !!token;
     }
 }


### PR DESCRIPTION
**Descripción**
Este endpoint permite refrescar un token de acceso (access_token) utilizando un refresh_token válido, junto con la autenticación del company mediante company_id y secret. Hemos tenido en cuenta la respuesta de éxito.

Resolve #24

**Verificación**
POST http://localhost:3000/oauth/refresh-token

En la pestaña "Body" en Postman, seleccionamos "raw" y "JSON"
```
{
    "id": 3,
    "secret": "secret_3",
    "refresh_token": "17157591158322882"
}

```
Body:
```
{
    "access_token": "17157603285223951",
    "expires_in": "2024-05-22T08:05:28.522Z"
}
```